### PR TITLE
Microbenchmark doc pages

### DIFF
--- a/doc/sphinx/10_Microbenchmarks/M0_Intro/introduction.rst
+++ b/doc/sphinx/10_Microbenchmarks/M0_Intro/introduction.rst
@@ -1,0 +1,5 @@
+LIST:
+
+- STREAM
+- DAXPY
+- OSU MB

--- a/doc/sphinx/10_Microbenchmarks/M0_Intro/introduction.rst
+++ b/doc/sphinx/10_Microbenchmarks/M0_Intro/introduction.rst
@@ -1,5 +1,13 @@
-LIST:
+***************************
+Microbenchmark Introduction
+***************************
+
+Microbenchmarks
+===============
 
 - STREAM
 - DAXPY
 - OSU MB
+- DGEMM
+- IOR
+- MDTEST

--- a/doc/sphinx/10_Microbenchmarks/M1_STREAM/STREAM.rst
+++ b/doc/sphinx/10_Microbenchmarks/M1_STREAM/STREAM.rst
@@ -1,0 +1,71 @@
+************************************
+STREAM
+************************************
+
+Purpose
+=======
+
+The `STREAM <https://github.com/jeffhammond/STREAM>`_ benchmark is a widely used benchmark for measuring memory bandwidth. It measures the sustainable memory bandwidth (in MB/s) of a computer system by performing simple read and write operations on large arrays. This guide will walk you through the process of running the STREAM benchmark using MPI on a single node of an HPC system.
+
+Prerequisites
+=============
+
+This benchmark requires MPI and a C/Fortran compiler
+
+Building
+========
+
+Generic
+=======
+
+1. Visit the official STREAM website: https://www.cs.virginia.edu/stream/
+2. Download the benchmark source code by clicking on the "Download STREAM benchmark" link.
+3. Extract the downloaded archive to a directory of your choice.
+
+Trinitite
+=========
+
+1. Open a terminal or command prompt and navigate to the directory where you extracted the STREAM benchmark source code.
+2. Inside the directory, you will find four source code files: `stream.c`, `stream.h`, `mysecond.c`, and `README`.
+3. Compile the benchmark by running the following command:
+
+   .. code-block:: bash
+
+      gcc -O3 -fopenmp -DSTREAM_ARRAY_SIZE=200000000 -o stream stream.c mysecond.c -lm
+
+   This command will compile the benchmark with optimization level 3 (-O3), enable OpenMP support (-fopenmp), define the array size (-DSTREAM_ARRAY_SIZE=200000000), and link the necessary math library (-lm).
+
+Running
+=======
+
+General
+=======
+
+Open a terminal or command prompt and navigate to the directory where you compiled the STREAM benchmark.
+To run the benchmark using MPI, execute the following command:
+
+   .. code-block:: bash
+
+      mpirun -np <num_processes> ./stream
+
+   Replace `<num_processes>` with the number of MPI processes you want to use. For example, if you want to use 4 MPI processes, the command will be:
+
+   .. code-block:: bash
+
+      mpirun -np 4 ./stream
+
+   The benchmark will run and display the results for the sustainable memory bandwidth (in MB/s) for the four operations: Copy, Scale, Add, and Triad.
+
+Trinitite
+=========
+
+Additional Considerations
+=========================
+
+- Ensure that you have a sufficient number of cores available on your Broadwell platform to achieve accurate benchmark results.
+- You can modify the STREAM_ARRAY_SIZE value in the compilation step to change the array size used by the benchmark. Adjusting the array size can help accommodate the available memory on your system.
+
+Conclusion
+==========
+
+The STREAM benchmark is a powerful tool for evaluating the memory bandwidth of a system. By following the steps outlined in this documentation, you can run the STREAM benchmark using MPI on a Broadwell platform. Remember to analyze the benchmark results carefully and consider other factors that may affect the performance of your system.

--- a/doc/sphinx/10_Microbenchmarks/M1_STREAM/STREAM.rst
+++ b/doc/sphinx/10_Microbenchmarks/M1_STREAM/STREAM.rst
@@ -1,71 +1,79 @@
-************************************
+******
 STREAM
-************************************
+******
 
 Purpose
 =======
 
-The `STREAM <https://github.com/jeffhammond/STREAM>`_ benchmark is a widely used benchmark for measuring memory bandwidth. It measures the sustainable memory bandwidth (in MB/s) of a computer system by performing simple read and write operations on large arrays. This guide will walk you through the process of running the STREAM benchmark using MPI on a single node of an HPC system.
+The `STREAM <https://github.com/jeffhammond/STREAM>`_ benchmark is a widely used benchmark for measuring memory bandwidth. It measures the sustainable memory bandwidth of a computer system by performing simple read and write operations on large arrays.
 
-Prerequisites
-=============
+Characteristics
+===============
 
-This benchmark requires MPI and a C/Fortran compiler
+STREAM is available:
+- Github: `STREAM <https://github.com/jeffhammond/STREAM>`_ 
+- Official site: `STREAM <https://www.cs.virginia.edu/stream/>`_
+- LANL Crossroads site: `STREAM <https://www.lanl.gov/projects/crossroads/_assets/docs/micro/stream-bench-crossroads-v1.0.0.tgz>`_
+
+Problem
+-------
+
+There are four memory operations that the STREAM benchmark measures: Copy, Scale, Add, and Triad.
+
+Copy - Copies data from one array to another:
+b[i] = a[i]
+
+Scale - Multiplies each array element by a constant, a daxpy operation.
+b[i] = q*a[i]
+
+Add - Adds two arrays element-wise:
+c[i] = a[i] + b[i]
+
+Triad - Multiply-add operation:
+a[i] = b[i] + q*c[i]
+
+These operations stress memory and floating point pipelines.They test memory transfer speed, computation speed, and different combinations of these two components of overall performance performance.
+
+Figure of Merit
+---------------
 
 Building
 ========
 
-Generic
-=======
+Adjustments to GOMP_CPU_AFFINITY may also be necessary.
 
-1. Visit the official STREAM website: https://www.cs.virginia.edu/stream/
-2. Download the benchmark source code by clicking on the "Download STREAM benchmark" link.
-3. Extract the downloaded archive to a directory of your choice.
+You can modify the STREAM_ARRAY_SIZE value in the compilation step to change the array size used by the benchmark. Adjusting the array size can help accommodate the available memory on your system.
 
-Trinitite
-=========
+RHEL Systems
+------------
 
-1. Open a terminal or command prompt and navigate to the directory where you extracted the STREAM benchmark source code.
-2. Inside the directory, you will find four source code files: `stream.c`, `stream.h`, `mysecond.c`, and `README`.
-3. Compile the benchmark by running the following command:
-
-   .. code-block:: bash
-
-      gcc -O3 -fopenmp -DSTREAM_ARRAY_SIZE=200000000 -o stream stream.c mysecond.c -lm
-
-   This command will compile the benchmark with optimization level 3 (-O3), enable OpenMP support (-fopenmp), define the array size (-DSTREAM_ARRAY_SIZE=200000000), and link the necessary math library (-lm).
+CrayOS Systems
+--------------
 
 Running
 =======
 
-General
-=======
+.. code-block:: bash
 
-Open a terminal or command prompt and navigate to the directory where you compiled the STREAM benchmark.
-To run the benchmark using MPI, execute the following command:
+  mpirun -np <num_processes> ./stream
 
-   .. code-block:: bash
+Replace `<num_processes>` with the number of MPI processes you want to use. For example, if you want to use 4 MPI processes, the command will be:
 
-      mpirun -np <num_processes> ./stream
+.. code-block:: bash
 
-   Replace `<num_processes>` with the number of MPI processes you want to use. For example, if you want to use 4 MPI processes, the command will be:
+  mpirun -np 4 ./stream
 
-   .. code-block:: bash
+Input
+-----
 
-      mpirun -np 4 ./stream
+Independent Variables
+---------------------
 
-   The benchmark will run and display the results for the sustainable memory bandwidth (in MB/s) for the four operations: Copy, Scale, Add, and Triad.
+Dependent Variable(s)
+---------------------
 
-Trinitite
-=========
+1. Maximum bandwidth while utilizing all hardware cores and threads. MAX_BW
+2. A minimum number of cores and threads that achieves MAX_BW. MIN_CT 
 
-Additional Considerations
-=========================
-
-- Ensure that you have a sufficient number of cores available on your Broadwell platform to achieve accurate benchmark results.
-- You can modify the STREAM_ARRAY_SIZE value in the compilation step to change the array size used by the benchmark. Adjusting the array size can help accommodate the available memory on your system.
-
-Conclusion
-==========
-
-The STREAM benchmark is a powerful tool for evaluating the memory bandwidth of a system. By following the steps outlined in this documentation, you can run the STREAM benchmark using MPI on a Broadwell platform. Remember to analyze the benchmark results carefully and consider other factors that may affect the performance of your system.
+Example Results
+===============

--- a/doc/sphinx/10_Microbenchmarks/M2_DAXPY/DAXPY.rst
+++ b/doc/sphinx/10_Microbenchmarks/M2_DAXPY/DAXPY.rst
@@ -1,0 +1,45 @@
+*****
+DAXPY
+*****
+
+Purpose
+=======
+
+Daxpy is a loose acronym that stands for "Double (precision) ax plus y".
+
+The daxpy benchmark is a simple program used to test and measure the performance of basic linear algebra operations on a computer system. It implements the operation y += ax where a is a scalar, and x and y are vectors. The daxpy benchmark provides a simple, standardized way to test the low-level computational performance of different computer systems for a basic but essential linear algebra operation. It serves as a baseline indicator of speed for more complex programs.
+
+The benchmark is small and simple enough that the performance is dominated by computation speed and memory access. The daxpy operation is broadly representative of operations common in scientific and engineering applications. 
+
+Characteristics
+===============
+
+Problem
+-------
+
+Figure of Merit
+---------------
+
+Building
+========
+
+RHEL Systems
+------------
+
+CrayOS Systems
+--------------
+
+Running
+=======
+
+Input
+-----
+
+Independent Variables
+---------------------
+
+Dependent Variable(s)
+---------------------
+
+Example Results
+===============

--- a/doc/sphinx/10_Microbenchmarks/M3_DGEMM/DGEMM.rst
+++ b/doc/sphinx/10_Microbenchmarks/M3_DGEMM/DGEMM.rst
@@ -1,0 +1,44 @@
+*****
+DGEMM
+*****
+
+Purpose
+=======
+
+The DGEMM benchmark measures the sustained floating-point rate of a single node.
+
+Characteristics
+===============
+
+- LANL Crossroads Site: `DGEMM <https://www.lanl.gov/projects/crossroads/_assets/docs/micro/mtdgemm-crossroads-v1.0.0.tgz>`_
+
+Problem
+-------
+
+Figure of Merit
+---------------
+
+Building
+========
+
+RHEL Systems
+------------
+
+CrayOS Systems
+--------------
+
+Running
+=======
+
+Input
+-----
+
+Independent Variables
+---------------------
+
+Dependent Variable(s)
+---------------------
+
+Example Results
+===============
+

--- a/doc/sphinx/10_Microbenchmarks/M4_IOR/IOR.rst
+++ b/doc/sphinx/10_Microbenchmarks/M4_IOR/IOR.rst
@@ -1,0 +1,48 @@
+***
+IOR
+***
+
+Purpose
+=======
+
+IOR is used for testing performance of parallel file systems using various interfaces and access patterns.
+
+Characteristics
+===============
+
+IOR is available:
+- Github: `IOR <https://github.com/hpc/ior>`_
+- LANL Crossroads Site: `IOR <https://www.lanl.gov/projects/crossroads/_assets/docs/micro/ior-3.0.1-xroads_v1.0.0.tgz>`_
+
+The github repo also contains mdtest.
+
+Problem
+-------
+
+Figure of Merit
+---------------
+
+Building
+========
+
+RHEL Systems
+------------
+
+CrayOS Systems
+--------------
+
+Running
+=======
+
+Input
+-----
+
+Independent Variables
+---------------------
+
+Dependent Variable(s)
+---------------------
+
+Example Results
+===============
+

--- a/doc/sphinx/10_Microbenchmarks/M5_OSUMB/OSUMB.rst
+++ b/doc/sphinx/10_Microbenchmarks/M5_OSUMB/OSUMB.rst
@@ -1,0 +1,64 @@
+*******************
+OSU Microbenchmarks
+*******************
+
+Purpose
+=======
+
+Characteristics
+===============
+
+- Official site: `OSUMB <https://mvapich.cse.ohio-state.edu/download/mvapich/osu-micro-benchmarks-7.2.tar.gz>`_
+
+Problem
+-------
+
+Figure of Merit
+---------------
+
+Building
+========
+
+On GPU enabled systems add these flags to the following configure lines: 
+
+.. code-block:: bash
+
+    --enable-cuda
+    --with-cuda-include=/path/to/cuda/include
+    --with-cuda-libpath=/path/to/cuda/lib
+
+.. code-block:: bash
+
+    ./configure --prefix=$INSTALL_DIR
+    make -j 
+    make -j install
+
+RHEL Systems
+------------
+
+.. code-block:: bash
+
+    export CC=mpicc CXX=mpicxx
+
+CrayOS Systems
+--------------
+
+.. code-block:: bash
+
+    exportCC=cc CXX=CC
+    
+Running
+=======
+
+Input
+-----
+
+Independent Variables
+---------------------
+
+Dependent Variable(s)
+---------------------
+
+Example Results
+===============
+

--- a/doc/sphinx/10_Microbenchmarks/M6_MDTEST/MDTEST.rst
+++ b/doc/sphinx/10_Microbenchmarks/M6_MDTEST/MDTEST.rst
@@ -1,0 +1,44 @@
+******
+MDTEST
+******
+
+Purpose
+=======
+
+MDtest is an MPI-based application for evaluating the metadata performance of a file system and has been designed to test parallel file systems. It can be run on any type of POSIX-compliant file system but has been designed to test the performance of parallel file systems.
+
+Characteristics
+===============
+
+-LANL Crossroads Site: `MDTEST <https://www.lanl.gov/projects/crossroads/_assets/docs/micro/mdtest-1.8.4-xroads_v1.0.0.tgz>`_
+
+Problem
+-------
+
+Figure of Merit
+---------------
+
+Building
+========
+
+RHEL Systems
+------------
+
+CrayOS Systems
+--------------
+
+Running
+=======
+
+Input
+-----
+
+Independent Variables
+---------------------
+
+Dependent Variable(s)
+---------------------
+
+Example Results
+===============
+

--- a/doc/sphinx/1_branson/branson.rst
+++ b/doc/sphinx/1_branson/branson.rst
@@ -1,6 +1,6 @@
-******
+*******
 Branson
-******
+*******
 
 This is the documentation for the ATS-5 Benchmark Branson - 3D hohlraum single node. 
  

--- a/doc/sphinx/index.rst
+++ b/doc/sphinx/index.rst
@@ -28,6 +28,18 @@ ATS Benchmarks Project
 
    9_appendix/build_docs
 
+.. toctree::
+   :numbered:
+   :maxdepth: 3
+   :caption: Microbenchmarks:
+
+   10_Microbenchmarks/M0_INTRO/introduction
+   10_Microbenchmarks/M1_STREAM/STREAM
+   10_Microbenchmarks/M2_DAXPY/DAXPY
+   10_Microbenchmarks/M3_DGEMM/DGEMM
+   10_Microbenchmarks/M4_IOR/IOR
+   10_Microbenchmarks/M5_OSUMB/OSUMB
+   10_Microbenchmarks/M6_MDTEST/MDTEST
 
 .. Indices and tables
    ==================

--- a/doc/sphinx/wrk/skeleton.rst
+++ b/doc/sphinx/wrk/skeleton.rst
@@ -1,0 +1,40 @@
+********
+SKELETON
+********
+
+Purpose
+=======
+
+Characteristics
+===============
+
+Problem
+-------
+
+Figure of Merit
+---------------
+
+Building
+========
+
+RHEL Systems
+------------
+
+CrayOS Systems
+--------------
+
+Running
+=======
+
+Input
+-----
+
+Independent Variables
+---------------------
+
+Dependent Variable(s)
+---------------------
+
+Example Results
+===============
+


### PR DESCRIPTION
I created pages for all the docs, and added them to the index. All the microbenchmarks now have a unique skeleton which is partially filled in. Also there's a skeleton.rst file in wrk to quickly create new outlines for documentation pages. 

I haven't completed any of the pages, but all are started. I realized I need some more specialized information on how to configure and execute some of the tests in line with our previous practices. I'll be consulting with the members of PRE-Team responsible for each test this week to fill in most of the blanks, (all the blanks for DGEMM, STREAM, and IOR).